### PR TITLE
fix(security): rotate RCON password via env var, untrack .env, fix hostname typo

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# Quake 3 Server Variables
-QUAKE3_SERVER_IMAGE_TAG=heyvaldemar/quake3-server:latest
-QUAKE3_SERVER_IP_OR_HOSTNAME=0.0.0.0

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Quake 3 Server Variables
+# Copy this file to `.env` and fill in each value before `docker compose up`.
+# `.env` is gitignored — never commit your real values.
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Image tag to pull from Docker Hub.
+# Pin to an exact semver (e.g. `v2.0.0`) for reproducible deployments;
+# use `:latest` only for dev/testing.
+# ──────────────────────────────────────────────────────────────────────────────
+QUAKE3_SERVER_IMAGE_TAG=heyvaldemar/quake3-server:latest
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public IP or DNS hostname of the server host.
+# Used by the QuakeJS web client for auto-discovery. `0.0.0.0` binds every
+# interface; set a real address/hostname if players connect from outside.
+# ──────────────────────────────────────────────────────────────────────────────
+QUAKE3_SERVER_IP_OR_HOSTNAME=0.0.0.0
+
+# ──────────────────────────────────────────────────────────────────────────────
+# RCON (remote console) password.
+# REQUIRED. Administers the server remotely via the Quake 3 `rcon` command.
+# Anyone with this value can kick/ban players, change maps, shutdown the
+# server, etc. Generate a strong random value, e.g.:
+#     openssl rand -base64 24 | tr -d '/+=' | head -c 32
+# Rotate if suspected of being leaked.
+# ──────────────────────────────────────────────────────────────────────────────
+RCON_PASSWORD=change_me_before_first_start

--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,8 @@ xcuserdata/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/git,macos,xcode,jekyll,packer,ansible,vagrant,windows,notepadpp,terraform,powershell,terragrunt,sublimetext,ansibletower,visualstudiocode,linux
+
+### Project-specific ###
+# Environment file for docker-compose — may contain secrets (RCON_PASSWORD).
+# Users should copy .env.example to .env locally and fill in values.
+.env

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 📙 The complete installation guide is available on my [website](https://www.heyvaldemar.com/install-quake3-server-using-docker-compose/).
 
-❗ Change variables in the `.env` and `server.cfg` to meet your requirements.
+❗ Copy `.env.example` to `.env` and set `RCON_PASSWORD` (required) plus any other variables before first start.
 
-💡 Note that the `.env` file and `server.cfg` file should be in the same directory as `quake3-server-docker-compose.yml`.
+💡 `.env` and `server.cfg` must sit in the same directory as `quake3-server-docker-compose.yml`.
+
+> ⚠️ The pre-rotation RCON password that was previously hardcoded in `server.cfg` is compromised (it remains in git history). Anyone who deployed with the old configuration should rotate their live RCON password.
 
 Deploy Quake 3 Server using Docker Compose:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,56 @@
 #!/bin/sh
+#
+# Configure and start the QuakeJS server and client.
+#
+# - Substitutes the %RCON_PASSWORD% placeholder in every server.cfg that was
+#   copied/mounted into the container with the value of $RCON_PASSWORD.
+# - Points the QuakeJS web client at the current server's hostname.
+# - Starts Apache (serves the web client on :80) and node ioq3ded
+#   (the dedicated Quake 3 server on :27960) under the entrypoint PID.
+set -eu
 
-# This script is used to configure and start the QuakeJS server and client.
+# Required secret: RCON password. Must be set via env; no sensible default.
+: "${RCON_PASSWORD:?RCON_PASSWORD env var must be set; generate with: openssl rand -base64 24 | tr -d '/+=' | head -c 32}"
 
-# Navigate to the directory containing the QuakeJS web assets
+# Reject the .env.example placeholder value so a user who cp'd the example
+# file but forgot to edit it fails fast rather than shipping a predictable
+# password to every public Quake 3 client scanner on the internet.
+case "${RCON_PASSWORD}" in
+  change_me*)
+    echo "ERROR: RCON_PASSWORD is still the .env.example placeholder value." >&2
+    echo "       Generate a real one: openssl rand -base64 24 | tr -d '/+=' | head -c 32" >&2
+    echo "       Then set it in .env (compose) or as a container env var." >&2
+    exit 1
+    ;;
+esac
+
+# Enforce a minimum length as a basic brute-force floor. 16 chars of the
+# alphabet in .env.example's generator ≈ 95 bits of entropy.
+if [ "${#RCON_PASSWORD}" -lt 16 ]; then
+  echo "ERROR: RCON_PASSWORD must be at least 16 characters (current length: ${#RCON_PASSWORD})." >&2
+  echo "       Generate a strong value: openssl rand -base64 24 | tr -d '/+=' | head -c 32" >&2
+  exit 1
+fi
+
+# Inject the RCON password into every server.cfg the image ships (baseq3,
+# cpma). If the host volume-mounts its own server.cfg via docker-compose,
+# that file is rewritten here too so compose users never have to edit the
+# config.
+for cfg in /quakejs/base/baseq3/server.cfg /quakejs/base/cpma/server.cfg; do
+  if [ -f "$cfg" ]; then
+    sed -i "s|%RCON_PASSWORD%|${RCON_PASSWORD}|g" "$cfg"
+  fi
+done
+
+# Update the QuakeJS web client to use the current server's hostname so
+# browser-based clients connect to the same machine that served the page.
 cd /var/www/html
-
-# Update the hostname for the QuakeJS client to use the current server's hostname
-# This replaces the default 'quakejs:' with the current server's hostname
 sed -i "s/'quakejs:/window.location.hostname + ':/g" index.html
 
-# Start the Apache2 service to serve the QuakeJS client
-# This ensures that the QuakeJS client is accessible via a web browser
+# Start Apache (serves /var/www/html on :80). Backgrounded via init.d.
 /etc/init.d/apache2 start
 
-# Navigate to the QuakeJS server directory
+# Start the QuakeJS dedicated server. `exec` replaces the shell so node
+# becomes PID 1 and receives SIGTERM/SIGINT directly.
 cd /quakejs
-
-# Start the QuakeJS dedicated server with the appropriate settings and configurations
-# This command starts the QuakeJS server with the baseq3 game settings, sets it to dedicated mode, and executes the server.cfg configuration file
-node build/ioq3ded.js +set fs_game baseq3 set dedicated 1 +exec server.cfg
+exec node build/ioq3ded.js +set fs_game baseq3 set dedicated 1 +exec server.cfg

--- a/quake3-server-docker-compose.yml
+++ b/quake3-server-docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - ./server.cfg:/quakejs/base/baseq3/server.cfg
     environment:
       SERVER: ${QUAKE3_SERVER_IP_OR_HOSTNAME}
+      RCON_PASSWORD: ${RCON_PASSWORD:?RCON_PASSWORD must be set in .env}
     ports:
       - "80:80"
       - "27960:27960"

--- a/server.cfg
+++ b/server.cfg
@@ -1,5 +1,5 @@
 // Server name
-seta sv_hostname "heyvaldemar.com - Minecraft Server"
+seta sv_hostname "heyvaldemar.com - Quake 3 Server"
 // Message of the day
 seta g_motd "heyvaldemar.com - Welcome to Valdemars Quake 3 Server"
 // Max players
@@ -27,8 +27,8 @@ seta bot_nochat 0
 seta g_spskill 3
 // This fills the server with bots to satisfy the minimum
 seta bot_minplayers 3
-// RCON Password
-seta rconpassword "FDyzDH8MowfpuwSyBfoWnaS"
+// RCON Password (substituted at container startup from the RCON_PASSWORD env var by entrypoint.sh; see .env.example)
+seta rconpassword "%RCON_PASSWORD%"
 // Map change order
 set d1 "map q3dm1 ; set nextmap vstr d2"
 set d2 "map q3dm7 ; set nextmap vstr d3"


### PR DESCRIPTION
## Summary

**Security fix.** The repository's `server.cfg` committed a hardcoded RCON password (`FDyzDH8MowfpuwSyBfoWnaS`) from the initial commit onward. RCON gives remote administrative control over a running Quake 3 server — anyone who has that password can kick/ban players, change maps, and run arbitrary rcon commands against any server deployed with the shipped config.

This PR removes the hardcoded value and injects it from the `RCON_PASSWORD` environment variable at container startup, with defensive validation against the most realistic footgun: the user who copied `.env.example` but forgot to edit it.

This is the first PR in a larger hardening series aligning this repo's posture with `aws-kubectl-docker`. A full README rewrite, supply-chain attestations, and non-root v2.0 breaking release are planned in follow-up PRs.

## Threat that is actually fixed

- Before: `server.cfg` on `main` said `seta rconpassword "FDyzDH8MowfpuwSyBfoWnaS"`. Deploying the `docker-compose.yml` verbatim produced a live server with that exact RCON password. The repo is public; the password was indexable.
- After: `server.cfg` on `main` says `seta rconpassword "%RCON_PASSWORD%"`. The container fails fast at startup if `RCON_PASSWORD` is unset, still the placeholder value, or shorter than 16 characters. `docker-compose.yml` fails early with a clear error if the user skipped setting it in `.env`.

The old password remains in git history. That's intentional — `git filter-repo` is a heavier operation with force-push blast radius, and the old password is no longer used by any live code. Anyone who deployed with the previous config should rotate their server's live RCON password.

## What changed per file

- **`server.cfg`:**
  - Line 2: `sv_hostname` typo corrected — the previous value said "Minecraft Server" (copy-paste leftover from another config template).
  - Line 31: `seta rconpassword "%RCON_PASSWORD%"` placeholder, substituted at container start by `entrypoint.sh`.
- **`entrypoint.sh`** (hardened):
  - `set -eu` so any failed command aborts container start instead of silently continuing.
  - Fails fast with a helpful message if `RCON_PASSWORD` is empty or unset. Error message includes the `openssl rand` one-liner to generate a strong value.
  - **Rejects `.env.example` placeholder values (`change_me_*`)** so users who copied the example file but forgot to edit it fail fast instead of shipping a predictable password to every Quake 3 server scanner on the internet.
  - **Enforces minimum 16-character length** on `RCON_PASSWORD` as a basic brute-force floor.
  - `sed`-injects the password into every `server.cfg` the image ships (`baseq3/server.cfg`, `cpma/server.cfg`). Host-mounted config via compose is rewritten in place for the same reason — compose users never edit the config file.
  - `exec node ...` so the node process replaces the shell as PID 1 and receives `SIGTERM`/`SIGINT` directly. Previously node ran as a child of the shell, which swallowed signals.
- **`quake3-server-docker-compose.yml`:** passes `RCON_PASSWORD` through to the container with `${RCON_PASSWORD:?...}` syntax — compose fails early with a clear error if `.env` doesn't define it.
- **`.env`:** removed from tracking (`git rm --cached`). New `.env.example` documents every required variable and the password-generation command. `.env` is now gitignored.
- **`.gitignore`:** explicit `.env` exclusion appended.
- **`README.md`:** operational instructions updated to describe the new `.env.example` workflow + an advisory paragraph for users who deployed before this rotation.

## Test plan

- [ ] Build image locally: `docker build -t quake3-server:pr1-test .`
- [ ] Try to run with no `RCON_PASSWORD`: `docker run --rm quake3-server:pr1-test` — expect immediate fail with "RCON_PASSWORD env var must be set" message.
- [ ] Try to run with placeholder value: `docker run --rm -e RCON_PASSWORD=change_me_before_first_start quake3-server:pr1-test` — expect immediate fail with "still the .env.example placeholder value" error.
- [ ] Try to run with short password: `docker run --rm -e RCON_PASSWORD=tooshort quake3-server:pr1-test` — expect immediate fail with "must be at least 16 characters" error.
- [ ] Run with valid password: `docker run --rm -e RCON_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=' | head -c 32) quake3-server:pr1-test cat /quakejs/base/baseq3/server.cfg | grep rconpassword` — expect the placeholder substituted with the real value.
- [ ] `shellcheck entrypoint.sh` — passes (verified locally, koalaman/shellcheck-alpine:stable).
- [ ] Full compose stack: copy `.env.example` to `.env`, set `RCON_PASSWORD`, `docker compose up` — expect server starts without error.
- [ ] Post-merge: the `publish.yml` workflow will rebuild and push the image with the new placeholder-based config. Anyone currently running `:latest` gets the new config on pull, fails fast until they add `RCON_PASSWORD` to their env. This is intentional — it forces rotation.

## What's next

This PR closes the security gap. The remaining plan (in order):

1. Community files + brand consistency (`LICENSE`, `SECURITY.md`, `CHANGELOG.md`, delete `.github/FUNDING.yml`, full README rewrite aligned with `aws-kubectl-docker` structure)
2. Dockerfile + CI supply-chain hardening (multi-stage, digest-pinned base, OCI labels, pinned action SHAs, SBOM, SLSA provenance, cosign signing, Trivy SARIF, Docker Hub README sync)
3. OpenSSF Scorecard workflow + badge
4. Docker Hub tag cleanup workflow
5. Non-root `v2.0` breaking release (USER 10001:0, Apache `setcap` for port 80, `v1-maintenance` floating tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
